### PR TITLE
Add images for running npm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ before_script:
 env:
   - VERSION=4/onbuild
   - VERSION=4/slim
+  - VERSION=4/test
   - VERSION=5/onbuild
   - VERSION=5/slim
+  - VERSION=5/test
 
 language: bash
 
 script:
   - docker build -t "$IMAGE" "$VERSION"
-  - docker build "test/$VERSION"
+  - "[[ -f test/$VERSION/Dockerfile ]] && docker build test/$VERSION || true"
 
 services: docker

--- a/4/test/Dockerfile
+++ b/4/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM mhart/alpine-node:4
+
+# Add gcc and git support for native dependencies.
+RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
+
+# Change the working directory.
+WORKDIR /app
+
+# Install modules and run tests.
+CMD ["sh", "-c", "npm install --unsafe-perm && npm test"]

--- a/5/test/Dockerfile
+++ b/5/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM mhart/alpine-node:5
+
+# Add gcc and git support for native dependencies.
+RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
+
+# Change the working directory.
+WORKDIR /app
+
+# Install modules and run tests.
+CMD ["sh", "-c", "npm install --unsafe-perm && npm test"]


### PR DESCRIPTION
This allows simplifying the `docker-compose.yml` file of packages to:

```
sut:
  image: seegno/node:5-test
  volumes:
    - .:/app
```

This image is necessary because the volume is mounted with permissions which are not accessible by the `node` user of the other images.
