### PR TITLE
Add npm config to set node dir globally

### DIFF
--- a/7/onbuild/Dockerfile
+++ b/7/onbuild/Dockerfile
@@ -49,6 +49,9 @@ RUN chown -R node /home/node
 # Change the user to avoid running as `root`.
 USER node
 
+# Allow building binary dependencies from node's source.
+RUN npm config set nodedir /node-${VERSION}
+
 # Install dependencies.
 ONBUILD COPY *.json ./
 ONBUILD RUN npm install --ignore-scripts

--- a/7/slim/Dockerfile
+++ b/7/slim/Dockerfile
@@ -49,6 +49,9 @@ RUN chown -R node /home/node
 # Change the user to avoid running as `root`.
 USER node
 
+# Allow building binary dependencies from node's source.
+RUN npm config set nodedir /node-${VERSION}
+
 # Copy package.json and npm-shrinkwrap.json if they exist.
 ONBUILD COPY *.json ./
 

--- a/7/test/Dockerfile
+++ b/7/test/Dockerfile
@@ -40,5 +40,8 @@ RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 # Change the working directory.
 WORKDIR /app
 
+# Allow building binary dependencies from node's source.
+RUN npm config set nodedir /node-${VERSION}
+
 # Install modules and run tests.
 CMD ["sh", "-c", "npm install --unsafe-perm && npm test"]


### PR DESCRIPTION
Add npm config to set node dir globally so that node-gyp and friends can compile against node's source successfully.
