### PR TITLE
Replace `base` build in yarn variants

### DIFF
--- a/4/onbuild-yarn/Dockerfile
+++ b/4/onbuild-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-4
+FROM mhart/alpine-node:4
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/4/slim-yarn/Dockerfile
+++ b/4/slim-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-4
+FROM mhart/alpine-node:4
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/4/test-yarn/Dockerfile
+++ b/4/test-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-4
+FROM mhart/alpine-node:4
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Change the working directory.
 WORKDIR /app

--- a/5/onbuild-yarn/Dockerfile
+++ b/5/onbuild-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-5
+FROM mhart/alpine-node:5
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/5/slim-yarn/Dockerfile
+++ b/5/slim-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-5
+FROM mhart/alpine-node:5
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/5/test-yarn/Dockerfile
+++ b/5/test-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-5
+FROM mhart/alpine-node:5
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Change the working directory.
 WORKDIR /app

--- a/6/onbuild-yarn/Dockerfile
+++ b/6/onbuild-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-6
+FROM mhart/alpine-node:6
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/6/slim-yarn/Dockerfile
+++ b/6/slim-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-6
+FROM mhart/alpine-node:6
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/6/test-yarn/Dockerfile
+++ b/6/test-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-6
+FROM mhart/alpine-node:6
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Change the working directory.
 WORKDIR /app

--- a/7/onbuild-yarn/Dockerfile
+++ b/7/onbuild-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-7
+FROM mhart/alpine-node:7
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/7/slim-yarn/Dockerfile
+++ b/7/slim-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-7
+FROM mhart/alpine-node:7
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Add a user to avoid running node as `root`.
 RUN adduser -S node

--- a/7/test-yarn/Dockerfile
+++ b/7/test-yarn/Dockerfile
@@ -1,18 +1,10 @@
-FROM mhart/alpine-node:base-7
+FROM mhart/alpine-node:7
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
-ARG YARN_VERSION=v0.16.1
-
-ENV PATH /usr/local/lib/yarn/bin/:$PATH
-
-RUN apk --no-cache --virtual yarn-dependencies add ca-certificates openssl tar \
-  && update-ca-certificates \
-  && mkdir /usr/local/lib/yarn/ \
-  && wget -O - https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz | tar -C /usr/local/lib/yarn/ --strip-components 1 -zxvf - \
-  && apk del yarn-dependencies
+RUN npm install -g yarn
 
 # Change the working directory.
 WORKDIR /app


### PR DESCRIPTION
Package installation fails if native modules are used.

Reference: https://github.com/mhart/alpine-node/issues/35.