### PR TITLE
Update base image to official node repository

### DIFF
--- a/4/onbuild-yarn/Dockerfile
+++ b/4/onbuild-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/4/onbuild/Dockerfile
+++ b/4/onbuild/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/4/slim-yarn/Dockerfile
+++ b/4/slim-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/4/slim/Dockerfile
+++ b/4/slim/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/4/test-yarn/Dockerfile
+++ b/4/test-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/4/test/Dockerfile
+++ b/4/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:4
+FROM node:4-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/5/onbuild-yarn/Dockerfile
+++ b/5/onbuild-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/5/onbuild/Dockerfile
+++ b/5/onbuild/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/5/slim-yarn/Dockerfile
+++ b/5/slim-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/5/slim/Dockerfile
+++ b/5/slim/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/5/test-yarn/Dockerfile
+++ b/5/test-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/5/test/Dockerfile
+++ b/5/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5
+FROM node:5-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/6/onbuild-yarn/Dockerfile
+++ b/6/onbuild-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/6/onbuild/Dockerfile
+++ b/6/onbuild/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/6/slim-yarn/Dockerfile
+++ b/6/slim-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/6/slim/Dockerfile
+++ b/6/slim/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/6/test-yarn/Dockerfile
+++ b/6/test-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/6/test/Dockerfile
+++ b/6/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6
+FROM node:6-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/7/onbuild-yarn/Dockerfile
+++ b/7/onbuild-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/7/onbuild/Dockerfile
+++ b/7/onbuild/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/7/slim-yarn/Dockerfile
+++ b/7/slim-yarn/Dockerfile
@@ -1,13 +1,10 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
 
 # Add yarn.
 RUN npm install -g yarn
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/7/slim/Dockerfile
+++ b/7/slim/Dockerfile
@@ -1,10 +1,7 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python
-
-# Add a user to avoid running node as `root`.
-RUN adduser -S node
 
 # Change the working directory.
 WORKDIR /home/node/app

--- a/7/test-yarn/Dockerfile
+++ b/7/test-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/7/test/Dockerfile
+++ b/7/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:7
+FROM node:7-alpine
 
 # Add gcc and git support for native dependencies.
 RUN apk --no-cache --virtual build-dependencies add g++ gcc git make python

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ $ docker run --rm -it node
 
 ## Image Variants
 
-All of the images are based on [alpine-node](https://github.com/mhart/alpine-node).
+All of the images are based on [node:alpine](https://hub.docker.com/r/library/node).
 
-The `seegno/node` image comes in multiple flavors. Only the major version is tracked as there is a linked dependency to [alpine-node](https://github.com/mhart/alpine-node) on Docker Hub.
+The `seegno/node` image comes in multiple flavors. Only the major version is tracked as there is a linked dependency to [node:alpine](https://hub.docker.com/r/library/node/) on Docker Hub.
 
 All images come with a `yarn` variant (e.g. `seegno/node:<version>-yarn`, `seegno/node:<version>-onbuild`).
 


### PR DESCRIPTION
This PR replaces `mhart/alpine-node` images with official node images `node:alpine`.